### PR TITLE
Local

### DIFF
--- a/lib/deep_cover/node/base.rb
+++ b/lib/deep_cover/node/base.rb
@@ -7,10 +7,9 @@ module DeepCover
     include HasChildHandler
     include CanAugmentChildren
     include HasLocal
+    include Rewriting
     extend CheckCompletion
     include FlowAccounting
-
-    has_child_handler('rewrite_%{name}')
 
     attr_reader :index, :parent, :children, :base_node
 
@@ -36,26 +35,6 @@ module DeepCover
 
     def [](v)
       children[v]
-    end
-
-    # Code to add before and after the node for covering purposes
-    def rewrite
-      '%{node}'
-    end
-
-    def resolve_rewrite(rule, context)
-      rule ||= '%{node}'
-      sources = context.tracker_sources
-      rule.split('%{node}').map{|s| s % {local: local_source, **sources} }
-    end
-
-    def rewrite_prefix_suffix
-      parent_prefix, parent_suffix = resolve_rewrite(parent.rewrite_child(self), parent)
-      prefix, suffix = resolve_rewrite(rewrite, self)
-      [
-        "#{parent_prefix}#{prefix}",
-        "#{suffix}#{parent_suffix}"
-      ]
     end
 
     ### Public API

--- a/lib/deep_cover/node/base.rb
+++ b/lib/deep_cover/node/base.rb
@@ -4,8 +4,14 @@ module DeepCover
     include Mixin
     include HasTracker
     include HasChild
+    include HasChildHandler
+    include CanAugmentChildren
     include HasLocal
     extend CheckCompletion
+
+    has_child_handler('%{name}_flow_entry_count')
+    has_child_handler('rewrite_%{name}')
+
     attr_reader :index, :parent, :children, :base_node
 
     def initialize(base_node, parent: raise, index: 0, base_children: base_node.children)

--- a/lib/deep_cover/node/base.rb
+++ b/lib/deep_cover/node/base.rb
@@ -8,8 +8,8 @@ module DeepCover
     include CanAugmentChildren
     include HasLocal
     extend CheckCompletion
+    include FlowAccounting
 
-    has_child_handler('%{name}_flow_entry_count')
     has_child_handler('rewrite_%{name}')
 
     attr_reader :index, :parent, :children, :base_node
@@ -36,63 +36,6 @@ module DeepCover
 
     def [](v)
       children[v]
-    end
-
-    # Returns true iff it is executable and if was successfully executed
-    def was_executed?
-      # There is a rare case of non executable nodes that have important data in flow_entry_count / flow_completion_count,
-      # like `if cond; end`, so make sure it's actually executable first...
-      executable? && execution_count > 0
-    end
-
-    # Returns the control flow entered the node.
-    # The control flow can then either complete normally or be interrupted
-    #
-    # Implementation: This is always the responsibility of the parent; Nodes should not override.
-    def flow_entry_count
-      parent.child_flow_entry_count(self)
-    end
-
-    # Returns the number of times it changed the usual control flow (e.g. raised, returned, ...)
-    # Implementation: This is always deduced; Nodes should not override.
-    def flow_interrupt_count
-      flow_entry_count - flow_completion_count
-    end
-
-    ### These are refined by subclasses
-
-    # Returns true iff it is executable. Keywords like `end` are not executable, but literals like `42` are executable.
-    def executable?
-      true
-    end
-
-    # Returns number of times the node itself was "executed". Definition of executed depends on the node.
-    def execution_count
-      flow_entry_count
-    end
-
-    # Returns the number of times the control flow succesfully left the node.
-    # This is the responsability of the child Node, never of the parent.
-    # Must be refined if the child node may have an impact on control flow (raising, branching, ...)
-    def flow_completion_count
-      last = children_nodes_in_flow_order.last
-      return last.flow_completion_count if last
-      flow_entry_count
-    end
-
-    # Returns the number of time the control flow entered this child_node.
-    # This is the responsability of the Node, not of the child.
-    # Must be refined if the parent node may have an impact on control flow (raising, branching, ...)
-    def child_flow_entry_count(child)
-      handler_value = super
-      return handler_value if handler_value
-
-      prev = child.previous_sibling
-      if prev
-        prev.flow_completion_count
-      else
-        flow_entry_count
-      end
     end
 
     # Code to add before and after the node for covering purposes

--- a/lib/deep_cover/node/block.rb
+++ b/lib/deep_cover/node/block.rb
@@ -32,7 +32,11 @@ module DeepCover
       has_tracker :body
       has_child call: {send: SendWithBlock, zsuper: SuperWithBlock, super: SuperWithBlock}
       has_child args: Args
-      has_child body: [Node, nil], rewrite: '%{body_tracker};%{node}', flow_entry_count: :body_tracker_hits
+      has_child body: [Node, nil],
+                rewrite: '%{body_tracker};%{node}',
+                flow_entry_count: :body_tracker_hits,
+                local_var_level: -> { local_var_level + 1 },
+                local_var_id: 0
 
       def executable?
         false

--- a/lib/deep_cover/node/def.rb
+++ b/lib/deep_cover/node/def.rb
@@ -7,7 +7,7 @@ module DeepCover
     has_child method_name: Symbol
     has_child signature: Args
     has_child body: [Node, nil], rewrite: '%{method_call_tracker};%{node};',
-      flow_entry_count: :method_call_tracker_hits
+      flow_entry_count: :method_call_tracker_hits, **RESET_LOCAL_VAR
     def children_nodes_in_flow_order
       []
     end
@@ -20,7 +20,7 @@ module DeepCover
     has_child method_name: Symbol
     has_child signature: Args
     has_child body: [Node, nil], rewrite: '%{method_call_tracker};%{node};',
-      flow_entry_count: :method_call_tracker_hits
+      flow_entry_count: :method_call_tracker_hits, **RESET_LOCAL_VAR
     def children_nodes_in_flow_order
       [singleton]
     end

--- a/lib/deep_cover/node/mixin/can_augment_children.rb
+++ b/lib/deep_cover/node/mixin/can_augment_children.rb
@@ -1,0 +1,56 @@
+module DeepCover
+  module Node::Mixin
+    module CanAugmentChildren
+      def self.included(base)
+        base.has_child_handler('remap_%{name}')
+        base.singleton_class.prepend ClassMethods
+      end
+
+      # Augment creates a covered node from the child_base_node.
+      # Caution: receiver is not fully constructed since it is also being augmented.
+      #          don't call `children`
+      def augment_children(child_base_nodes)
+        # Skip children that aren't node themselves (e.g. the `method` child of a :def node)
+        child_base_nodes.map.with_index do |child, child_index|
+          child_name = self.class.child_index_to_name(child_index, child_base_nodes.size) rescue binding.pry
+
+          klass = remap_child(child, child_name)
+          next child if !klass && !child.is_a?(Parser::AST::Node)
+
+          klass ||= self.class.factory(child.type, child_index)
+          klass.new(child, parent: self, index: child_index)
+        end
+      end
+      private :augment_children
+
+      module ClassMethods
+
+        # This handles the following shortcuts:
+        #   has_child foo: {type: NodeClass, ...}
+        # same as:
+        #   has_child foo: [], remap: {type: NodeClass, ...}
+        # same as:
+        #   has_child foo: [NodeClass, ...], remap: {type: NodeClass, ...}
+        #
+        def has_child(remap: nil, **h)
+          name, types = h.first
+          if types.is_a? Hash
+            raise "Use either remap or a hash as type but not both" if remap
+            remap = types
+            h[name] = types = []
+          end
+          if remap.is_a? Hash
+            type_map = remap
+            remap = -> (child) do
+              klass = type_map[child.class]
+              klass ||= type_map[child.type] if child.respond_to? :type
+              klass
+            end
+            types.concat(type_map.values).uniq!
+          end
+          super(**h, remap: remap)
+        end
+      end
+    end
+  end
+end

--- a/lib/deep_cover/node/mixin/check_completion.rb
+++ b/lib/deep_cover/node/mixin/check_completion.rb
@@ -9,7 +9,7 @@ module DeepCover
         include ExecutedAfterChildren
         alias_method :flow_completion_count, :completion_tracker_hits
         pre, post = outer.split('%{node}')
-        define_method(:rewrite) { "#{pre}(%{local}=#{inner};%{completion_tracker};__t=%{local})#{post}" }
+        define_method(:rewrite) { "#{pre}(%{local}=#{inner};%{completion_tracker};%{local}=%{local})#{post}" }
       end
     end
   end

--- a/lib/deep_cover/node/mixin/flow_accounting.rb
+++ b/lib/deep_cover/node/mixin/flow_accounting.rb
@@ -1,0 +1,69 @@
+module DeepCover
+  module Node::Mixin
+    module FlowAccounting
+      def self.included(base)
+        base.has_child_handler('%{name}_flow_entry_count')
+        base.include FlowEntryDefault
+      end
+
+      # Returns true iff it is executable and if was successfully executed
+      def was_executed?
+        # There is a rare case of non executable nodes that have important data in flow_entry_count / flow_completion_count,
+        # like `if cond; end`, so make sure it's actually executable first...
+        executable? && execution_count > 0
+      end
+
+      # Returns the control flow entered the node.
+      # The control flow can then either complete normally or be interrupted
+      #
+      # Implementation: This is always the responsibility of the parent; Nodes should not override.
+      def flow_entry_count
+        parent.child_flow_entry_count(self)
+      end
+
+      # Returns the number of times it changed the usual control flow (e.g. raised, returned, ...)
+      # Implementation: This is always deduced; Nodes should not override.
+      def flow_interrupt_count
+        flow_entry_count - flow_completion_count
+      end
+
+      ### These are refined by subclasses
+
+      # Returns true iff it is executable. Keywords like `end` are not executable, but literals like `42` are executable.
+      def executable?
+        true
+      end
+
+      # Returns number of times the node itself was "executed". Definition of executed depends on the node.
+      def execution_count
+        flow_entry_count
+      end
+
+      # Returns the number of times the control flow succesfully left the node.
+      # This is the responsability of the child Node, never of the parent.
+      # Must be refined if the child node may have an impact on control flow (raising, branching, ...)
+      def flow_completion_count
+        last = children_nodes_in_flow_order.last
+        return last.flow_completion_count if last
+        flow_entry_count
+      end
+
+      module FlowEntryDefault
+        # Returns the number of time the control flow entered this child_node.
+        # This is the responsability of the Node, not of the child.
+        # Must be refined if the parent node may have an impact on control flow (raising, branching, ...)
+        def child_flow_entry_count(child)
+          handler_value = super
+          return handler_value if handler_value
+
+          prev = child.previous_sibling
+          if prev
+            prev.flow_completion_count
+          else
+            flow_entry_count
+          end
+        end
+      end
+    end
+  end
+end

--- a/lib/deep_cover/node/mixin/has_child_handler.rb
+++ b/lib/deep_cover/node/mixin/has_child_handler.rb
@@ -1,0 +1,61 @@
+module DeepCover
+  module Node::Mixin
+    module HasChildHandler
+      def self.included(base)
+        base.extend ClassMethods
+      end
+
+      def call_child_handler template, child, child_name = nil
+        child_name ||= self.class.child_index_to_name(child.index, children.size) rescue binding.pry
+        method_name = template % {name: child_name}
+        if respond_to?(method_name)
+          args = [child] unless method(method_name).arity == 0
+          answer = send(method_name, *args)
+        end
+        answer
+      end
+      private :call_child_handler
+
+      module ClassMethods
+        def has_child_handler(template)
+          child_method_name = template % {name: 'child'}
+          action = template.gsub /_?%{name}_?/, ''
+          const_name = "#{Misc.camelize(action)}Handler"
+          class_eval <<-end_eval, __FILE__, __LINE__
+            module #{const_name}                                     # module RewriteHandler
+              module ClassMethods                                    #   module ClassMethods
+                def has_child(#{action}: nil, **h)                   #     def has_child(rewrite: nil, **h)
+                  name, types = h.first                              #       name, types = h.first
+                  define_child_handler(#{template.inspect},          #       define_child_handler('rewrite_%{child}',
+                    name, #{action})                                 #         name, rewrite)
+                  super(**h)                                         #       super(**h)
+                end                                                  #     end
+              end                                                    #   end
+
+              def #{child_method_name}(child, name = nil)            #   def rewrite_child(child, child_name = nil)
+                call_child_handler(#{template.inspect}, child, name) #     call_child_handler('rewrite_%{child}', child, child_name)
+              end                                                    #   end
+            end                                                      # end
+            include #{const_name}                                    # include RewriteHandler
+            singleton_class.prepend #{const_name}::ClassMethods      # singleton_class.prepend RewriteHandler::ClassMethods
+          end_eval
+        end
+
+        def define_child_handler(template, name, method)
+          method_name = template % {name: name}
+          case method
+          when nil
+            # Nothing to do
+          when Symbol
+            alias_method method_name, method
+          when Proc
+            define_method(method_name, &method)
+          else
+            define_method(method_name) {|*| method }
+          end
+        end
+        private :define_child_handler
+      end
+    end
+  end
+end

--- a/lib/deep_cover/node/mixin/has_local.rb
+++ b/lib/deep_cover/node/mixin/has_local.rb
@@ -1,17 +1,35 @@
 module DeepCover
   module Node::Mixin
+    RESET_LOCAL_VAR = {local_var_level: 0, local_var_id: 0}
+
     module HasLocal
       def self.included(base)
+        base.has_child_handler '%{name}_local_var_level'
+        base.has_child_handler '%{name}_local_var_id'
         base.extend ClassMethods
+        base.include HasLocalDefault
       end
 
-      def initialize(*)
-        @local_offset = covered_code.allocate_local if self.class.needs_local
-        super
+      def local_var_id
+        parent.child_local_var_id(self)
+      end
+
+      def local_var_level
+        parent.child_local_var_level(self)
       end
 
       def local_source
-        covered_code.local_source(@local_offset) if @local_offset
+        covered_code.local_var_source(level: local_var_level, id: local_var_id) if self.class.needs_local
+      end
+
+      module HasLocalDefault
+        def child_local_var_id(_child)
+          super || (local_var_id + (self.class.needs_local ? 1 : 0))
+        end
+
+        def child_local_var_level(_child)
+          super || local_var_level
+        end
       end
 
       module ClassMethods

--- a/lib/deep_cover/node/mixin/rewriting.rb
+++ b/lib/deep_cover/node/mixin/rewriting.rb
@@ -1,0 +1,29 @@
+module DeepCover
+  module Node::Mixin
+    module Rewriting
+      def self.included(base)
+        base.has_child_handler('rewrite_%{name}')
+      end
+
+      # Code to add before and after the node for covering purposes
+      def rewrite
+        '%{node}'
+      end
+
+      def resolve_rewrite(rule, context)
+        rule ||= '%{node}'
+        sources = context.tracker_sources
+        rule.split('%{node}').map{|s| s % {local: local_source, **sources} }
+      end
+
+      def rewrite_prefix_suffix
+        parent_prefix, parent_suffix = resolve_rewrite(parent.rewrite_child(self), parent)
+        prefix, suffix = resolve_rewrite(rewrite, self)
+        [
+          "#{parent_prefix}#{prefix}",
+          "#{suffix}#{parent_suffix}"
+        ]
+      end
+    end
+  end
+end

--- a/lib/deep_cover/node/module.rb
+++ b/lib/deep_cover/node/module.rb
@@ -24,7 +24,8 @@ module DeepCover
       has_tracker :body_entry
       has_child const: {const: ModuleName}
       has_child body: [Node, nil], rewrite: '%{body_entry_tracker};%{node}',
-        flow_entry_count: :body_entry_tracker_hits
+        flow_entry_count: :body_entry_tracker_hits, **RESET_LOCAL_VAR
+
 
       def execution_count
         body ? body_entry_tracker_hits : flow_completion_count
@@ -37,7 +38,7 @@ module DeepCover
       has_child const: {const: ModuleName}
       has_child inherit: [Node, nil]  # TODO
       has_child body: [Node, nil], rewrite: '%{body_entry_tracker};%{node}',
-        flow_entry_count: :body_entry_tracker_hits
+        flow_entry_count: :body_entry_tracker_hits, **RESET_LOCAL_VAR
 
       def execution_count
         body ? body_entry_tracker_hits : flow_completion_count
@@ -47,7 +48,7 @@ module DeepCover
     # class << foo
     class Sclass < Node
       has_child object: Node
-      has_child body: [Node, nil]
+      has_child body: [Node, nil], **RESET_LOCAL_VAR
       # TODO
     end
   end

--- a/lib/deep_cover/node/root.rb
+++ b/lib/deep_cover/node/root.rb
@@ -1,7 +1,8 @@
 module DeepCover
   class Node::Root < Node
     has_tracker :root
-    has_child main: Node, flow_entry_count: :root_tracker_hits, rewrite: -> {
+    has_child main: Node, flow_entry_count: :root_tracker_hits, **RESET_LOCAL_VAR,
+      rewrite: -> {
       "#{covered_code.trackers_setup_source};%{root_tracker};%{node}"
     }
     attr_reader :covered_code


### PR DESCRIPTION
Builds on `has_child_handler`.
Greedy locals.

Screams at a refactor to (re-)introduce defaults for handlers. I'll have to try and figure out why they were removed in the first place.

def/module/class => resets the local variable scopes
block => nested local variable scope

Anything else I'm forgetting? Seems too simple somehow.