### PR TITLE
Fix false positive of patch_gemfile

### DIFF
--- a/lib/deep_cover/cli/instrumented_clone_reporter.rb
+++ b/lib/deep_cover/cli/instrumented_clone_reporter.rb
@@ -106,16 +106,18 @@ module DeepCover
 
       def patch_gemfile
         gemfile = @dest_root.join('Gemfile')
+        deps = Bundler::Definition.build(gemfile, nil, nil).dependencies
+
+        return if deps.find { |e| e.name == 'deep-cover' }
+
         content = File.read(gemfile)
-        unless content =~ /gem 'deep-cover'/
-          puts "Patching Gemfile #{gemfile}"
-          File.write(gemfile, [
-                                '# This file was modified by DeepCover',
-                                content,
-                                "gem 'deep-cover', path: '#{File.expand_path(__dir__ + '/../../../')}'",
-                                '',
-                              ].join("\n"))
-        end
+        puts "Patching Gemfile #{gemfile}"
+        File.write(gemfile, [
+                              '# This file was modified by DeepCover',
+                              content,
+                              "gem 'deep-cover', path: '#{File.expand_path(__dir__ + '/../../../')}'",
+                              '',
+                            ].join("\n"))
       end
 
       def patch_rubocop


### PR DESCRIPTION
This pr will fix a false positive of patch_gemfile.

## Expected

Do not raise any error with this Gemfile, specified `deep-cover` with double-quotes.

```ruby
source "https://rubygems.org

gem "rspec"
gem "rake"
gem "deep-cover"
```

## Actual

Raise an error.

```
Running `bundle install`

[!] There was an error parsing `Gemfile`: You cannot specify the same gem twice coming from different sources.
You specified that deep-cover (>= 0) should come from an unspecified source and source at `/Users/hkdnet/.ghq/github.com/hkdnet/deep-cover-example/vendor/bundle/ruby/2.4.0/gems/deep-cover-0.1.16`
. Bundler cannot continue.
```