### PR TITLE
Handle require Pathname

### DIFF
--- a/lib/deep_cover/custom_requirer.rb
+++ b/lib/deep_cover/custom_requirer.rb
@@ -88,7 +88,7 @@ module DeepCover
     #     It is *NOT* recommended to simply delegate to the default #require, since it
     #     might not be safe to run part of the code again.
     def require(path)
-      path = path.to_s if path.kind_of?(Pathname)
+      path = path.to_s
       ext = File.extname(path)
       throw :use_fallback, :not_supported if ext == '.so'
       path += '.rb' if ext != '.rb'

--- a/lib/deep_cover/custom_requirer.rb
+++ b/lib/deep_cover/custom_requirer.rb
@@ -88,6 +88,7 @@ module DeepCover
     #     It is *NOT* recommended to simply delegate to the default #require, since it
     #     might not be safe to run part of the code again.
     def require(path)
+      path = path.to_s if path.kind_of?(Pathname)
       ext = File.extname(path)
       throw :use_fallback, :not_supported if ext == '.so'
       path += '.rb' if ext != '.rb'

--- a/spec/custom_requirer_spec.rb
+++ b/spec/custom_requirer_spec.rb
@@ -148,6 +148,15 @@ module DeepCover
         './test'.should actually_require('one/two/test.rb')
       end
 
+      it 'handles a Pathname instance' do
+        file_tree %w(pwd:one/two/
+                     one/two/test.rb
+                     one/two/three/test.rb
+)
+
+        Pathname('./test').should actually_require('one/two/test.rb')
+      end
+
       it 'a ./path ignores the load_path' do
         file_tree %w(one/two/test.rb
                      one/two/three/test.rb

--- a/spec/spec_helper.rb
+++ b/spec/spec_helper.rb
@@ -10,6 +10,7 @@ $SPEC_HELPER_TRIED = true
 
 require 'bundler/setup'
 require 'pry'
+require 'pathname'
 $LOAD_PATH.unshift('../covered_deep_cover') if ENV['CC']
 require 'deep_cover'
 require_relative 'specs_tools'


### PR DESCRIPTION
In our app we use following way of requiring a lot:

```ruby
require Rails.root.join('lib', 'foo.rb')
```
it breaks with `deep-cover` as require is being called w/ instance of Pathname, not string.