### PR TITLE
Prevent NameError by DeepCover::VERSION

### DIFF
--- a/lib/deep_cover/coverage/persistence.rb
+++ b/lib/deep_cover/coverage/persistence.rb
@@ -1,5 +1,7 @@
 # frozen_string_literal: true
 
+require 'deep_cover/version'
+
 module DeepCover
   require 'securerandom'
   class Coverage::Persistence


### PR DESCRIPTION
This patch prevents a `NameError` by referring `DeepCover::VERSION`.

# How to reproduce the error

First write `deep-cover` and `parser` in `Gemfile` in a Rails application like:

```ruby
group :development, :test do
  gem 'deep-cover', github: 'deep-cover/deep-cover'
  gem 'parser', git: 'https://github.com/marcandre/parser.git', branch: 'tree_rewriter_release'
end
```

Next, generate `bin/deep-cover` by `bundle binstubs deep-cover` and then execute `bin/deep-cover`.

```
$ bundle binstubs deep-cover
$ bin/deep-cover
Using rake 12.3.0
Using concurrent-ruby 1.0.5
Using i18n 0.9.1
...(snip)...
Using spring-watcher-listen 2.0.1
Using sqlite3 1.3.13
Using web-console 3.5.1
Bundle complete! 15 Gemfile dependencies, 82 gems now installed.
Use `bundle info [gemname]` to see where a bundled gem is installed.
Cloning...
Rewriting: |================================================================================================================================================================================================================================================================================================================================================| Time: 00:00:00
Rewriting: |================================================================================================================================================================================================================================================================================================================================================| Time: 00:00:00
Traceback (most recent call last):
        8: from bin/deep-cover:21:in `<main>'
        7: from bin/deep-cover:21:in `load'
        6: from /Users/mrkn/.rbenv/versions/2.5.0/lib/ruby/gems/2.5.0/bundler/gems/deep-cover-6b05d4f1fcfe/exe/deep-cover:7:in `<top (required)>'
        5: from /Users/mrkn/.rbenv/versions/2.5.0/lib/ruby/gems/2.5.0/bundler/gems/deep-cover-6b05d4f1fcfe/lib/deep_cover/cli/deep_cover.rb:83:in `go'
        4: from /Users/mrkn/.rbenv/versions/2.5.0/lib/ruby/gems/2.5.0/bundler/gems/deep-cover-6b05d4f1fcfe/lib/deep_cover/cli/instrumented_clone_reporter.rb:172:in `run'
        3: from /Users/mrkn/.rbenv/versions/2.5.0/lib/ruby/gems/2.5.0/bundler/gems/deep-cover-6b05d4f1fcfe/lib/deep_cover/cli/instrumented_clone_reporter.rb:147:in `cover'
        2: from /Users/mrkn/.rbenv/versions/2.5.0/lib/ruby/gems/2.5.0/bundler/gems/deep-cover-6b05d4f1fcfe/lib/deep_cover/coverage/base.rb:63:in `save'
        1: from /Users/mrkn/.rbenv/versions/2.5.0/lib/ruby/gems/2.5.0/bundler/gems/deep-cover-6b05d4f1fcfe/lib/deep_cover/coverage/persistence.rb:23:in `save'
/Users/mrkn/.rbenv/versions/2.5.0/lib/ruby/gems/2.5.0/bundler/gems/deep-cover-6b05d4f1fcfe/lib/deep_cover/coverage/persistence.rb:53:in `save_coverage': uninitialized constant DeepCover::VERSION (NameError)
```

  