### PR TITLE
allow to explicitly specify the main file

### DIFF
--- a/lib/deep_cover/cli/deep_cover.rb
+++ b/lib/deep_cover/cli/deep_cover.rb
@@ -42,6 +42,7 @@ module DeepCover
         o.separator ''
         o.string '-o', '--output', 'output folder', default: DEFAULTS[:output]
         o.string '-c', '--command', 'command to run tests', default: CLI_DEFAULTS[:command]
+        o.string '--main', 'main file', default: ''
         o.string '--reporter', 'reporter', default: DEFAULTS[:reporter]
         o.bool '--bundle', 'run bundle before the tests', default: CLI_DEFAULTS[:bundle]
         o.bool '--process', 'turn off to only redo the reporting', default: CLI_DEFAULTS[:process]

--- a/lib/deep_cover/cli/instrumented_clone_reporter.rb
+++ b/lib/deep_cover/cli/instrumented_clone_reporter.rb
@@ -99,9 +99,14 @@ module DeepCover
 
       # Back to global functionality
       def patch_main_ruby_files
-        each_main_ruby_files do |main|
-          puts "Patching #{main}"
-          patch_ruby_file(main)
+        if @options[:main].empty?
+          each_main_ruby_files do |main|
+            puts "Patching #{main}"
+            patch_ruby_file(main)
+          end
+        else
+          puts "Patching #{@options[:main]}"
+          patch_ruby_file(Pathname.new(@options[:main]).expand_path(@main_path))
         end
       end
 


### PR DESCRIPTION
The main use case for me is to be able to run a single test file using
minitest:

~~~
deep-cover -m test/test_plan.rb \
   --no-bundle \
   -c "ruby -Ilib -rminitest/autorun test/test_plan.rb"
~~~