### PR TITLE
Copy some methods from activesupport and remove the dependency

### DIFF
--- a/deep_cover.gemspec
+++ b/deep_cover.gemspec
@@ -46,7 +46,6 @@ Gem::Specification.new do |spec|
   spec.add_runtime_dependency 'pry'
 
   ### Dev dependencies
-  spec.add_development_dependency 'activesupport', '~> 4.0'
   spec.add_development_dependency 'bundler', '~> 1.15'
   spec.add_development_dependency 'psych', '>= 2.0'
   spec.add_development_dependency 'rake', '~> 12.0'

--- a/lib/deep_cover/tools/blank.rb
+++ b/lib/deep_cover/tools/blank.rb
@@ -1,0 +1,25 @@
+# frozen_string_literal: true
+
+module DeepCover
+  module Tools::Blank
+    BLANK_RE = /\A[[:space:]]*\z/
+
+    # Homemade poor-man's blank?
+    # Based, but modified, on https://github.com/rails/rails/blob/5-0-stable/activesupport/lib/active_support/core_ext/object/blank.rb
+    def blank?(obj)
+      if obj.is_a?(String)
+        obj.empty? || obj =~ BLANK_RE
+      else
+        obj.respond_to?(:empty?) ? !!obj.empty? : !obj
+      end
+    end
+
+    def present?(obj)
+      !blank?(obj)
+    end
+
+    def presence(obj)
+      obj if present?(obj)
+    end
+  end
+end

--- a/lib/deep_cover/tools/execute_sample.rb
+++ b/lib/deep_cover/tools/execute_sample.rb
@@ -23,8 +23,9 @@ module DeepCover
       source = to_execute.covered_source if to_execute.is_a?(CoveredCode)
       raise unless source
 
-      inner_msg = "#{e.class.name}: #{e.message}"
-      msg = "Exception when executing the sample:\n#{inner_msg.indent(4)}\n*Code follows*\n#{source}"
+      inner_msg = Tools.indent_string("#{e.class.name}: #{e.message}", 4)
+      source = Tools.indent_string(source, 4)
+      msg = "Exception when executing the sample:\n#{inner_msg}\n*Code follows*\n#{source}"
       new_exc = ExceptionInSample.new(msg)
       new_exc.set_backtrace(e.backtrace)
       raise new_exc

--- a/lib/deep_cover/tools/format_generated_code.rb
+++ b/lib/deep_cover/tools/format_generated_code.rb
@@ -15,7 +15,7 @@ module DeepCover
       inserts.each do |exp_limit, size|
         # Line index starts at 1, so array index returns the next line
         comment_line = generated_lines[exp_limit.line]
-        next unless comment_line.present?
+        next if Tools.blank?(comment_line)
         next unless comment_line.start_with?('#>')
         next if comment_line.start_with?('#>X')
         next unless comment_line.size >= exp_limit.column

--- a/lib/deep_cover/tools/indent_string.rb
+++ b/lib/deep_cover/tools/indent_string.rb
@@ -1,0 +1,26 @@
+# frozen_string_literal: true
+
+module DeepCover
+  module Tools::IndentString
+    # In-place implementation copied from active-support.
+    IMPLEMENTATION = ->(amount, indent_string = nil, indent_empty_lines = false) do
+      indent_string = indent_string || self[/^[ \t]/] || ' '
+      re = indent_empty_lines ? /^/ : /^(?!$)/
+      gsub!(re, indent_string * amount)
+    end
+
+    # Same as #indent! from active-support
+    # https://github.com/rails/rails/blob/10e1f1f9a129f2f197a44009a99b73b8ff9dbc0d/activesupport/lib/active_support/core_ext/string/indent.rb#L7
+    def indent_string!(string, *args)
+      string.instance_exec(*args, &IMPLEMENTATION)
+    end
+
+    # Same as #indent from active-support
+    # https://github.com/rails/rails/blob/10e1f1f9a129f2f197a44009a99b73b8ff9dbc0d/activesupport/lib/active_support/core_ext/string/indent.rb#L42
+    def indent_string(string, *args)
+      string = string.dup
+      indent_string!(string, *args)
+      string
+    end
+  end
+end

--- a/lib/deep_cover/tools/strip_heredoc.rb
+++ b/lib/deep_cover/tools/strip_heredoc.rb
@@ -1,0 +1,18 @@
+# frozen_string_literal: true
+
+module DeepCover
+  module Tools::StripHeredoc
+    # In-place implementation copied from active-support.
+    IMPLEMENTATION = -> do
+      gsub(/^#{scan(/^[ \t]*(?=\S)/).min}/, ''.freeze).tap do |stripped|
+        stripped.freeze if frozen?
+      end
+    end
+
+    # Same as #strip_heredoc from active-support
+    # https://github.com/rails/rails/blob/16574409f813e2197f88e4a06b527618d64d9ff0/activesupport/lib/active_support/core_ext/string/strip.rb#L22
+    def strip_heredoc(string)
+      string.instance_exec(&IMPLEMENTATION)
+    end
+  end
+end

--- a/spec/analyser/ruby25_like_branch_spec.rb
+++ b/spec/analyser/ruby25_like_branch_spec.rb
@@ -3,7 +3,6 @@
 require 'spec_helper'
 require 'tempfile'
 require 'coverage'
-require 'active_support/core_ext/string/strip'
 
 module DeepCover
   RSpec.describe Analyser::Ruby25LikeBranch do
@@ -30,7 +29,7 @@ module DeepCover
       match do |ruby_code|
         @ignore_shortcircuit = ignore_shortcircuit
         @executions = []
-        ruby_code = ruby_code.strip_heredoc
+        ruby_code = Tools.strip_heredoc(ruby_code)
         ruby_codes = [ruby_code.rstrip]
         unless ruby_code.include?('assert')
           extra_ruby_codes = ruby_codes.map { |c| c.gsub(/^(\s*)(\d+\s*$)/, '') }
@@ -76,7 +75,7 @@ module DeepCover
           msg << Tools.indent_string(execution.code.rstrip, 4)
 
           if @different_executions.include?(execution)
-            msg << <<-MSG.strip_heredoc
+            msg << Tools.strip_heredoc(<<-MSG)
               Expected something like:
                   #{execution.ruby_result.sort.to_h}
               but deep-dover generated something like:

--- a/spec/analyser/ruby25_like_branch_spec.rb
+++ b/spec/analyser/ruby25_like_branch_spec.rb
@@ -3,7 +3,6 @@
 require 'spec_helper'
 require 'tempfile'
 require 'coverage'
-require 'active_support/core_ext/string/indent'
 require 'active_support/core_ext/string/strip'
 
 module DeepCover
@@ -74,7 +73,7 @@ module DeepCover
             msg << 'Every mutation is bad. Displaying problem only for original sample:'
           end
           msg << 'For ruby code:'
-          msg << execution.code.rstrip.indent(4)
+          msg << Tools.indent_string(execution.code.rstrip, 4)
 
           if @different_executions.include?(execution)
             msg << <<-MSG.strip_heredoc

--- a/spec/analyser/ruby25_like_branch_spec.rb
+++ b/spec/analyser/ruby25_like_branch_spec.rb
@@ -45,7 +45,7 @@ module DeepCover
           ruby_codes.concat(ruby_codes.map { |c| c.gsub(/\bwhile\b(.*)/, 'until !(\1)') })
         end
 
-        ruby_codes += ruby_codes.map { |c| c.split("\n").select(&:present?).join("\n") }
+        ruby_codes += ruby_codes.map { |c| c.split("\n").select(&Tools.method(:present?)).join("\n") }
         ruby_codes.uniq!
 
         ruby_codes.each(&method(:execute))

--- a/spec/specs_tools.rb
+++ b/spec/specs_tools.rb
@@ -2,11 +2,10 @@
 
 require 'fileutils'
 
-require 'active_support/core_ext/object/blank'
 class Array
   def trim_blank
-    drop_while(&:blank?)
-      .reverse.drop_while(&:blank?).reverse
+    drop_while(&DeepCover::Tools.method(:blank?))
+      .reverse.drop_while(&DeepCover::Tools.method(:blank?)).reverse
   end
 end
 


### PR DESCRIPTION
It's annoying to sometimes not have access to useful methods. Also, sometimes, tests pass but would there would have exceptions at runtime because AS is only available in test.