### PR TITLE
Add minimum coverage check

### DIFF
--- a/lib/deep_cover/cli/commands/report.rb
+++ b/lib/deep_cover/cli/commands/report.rb
@@ -14,7 +14,7 @@ module DeepCover
       overall_coverage = coverage.analysis.overall
       minimum_coverage = processed_options.fetch('minimum-coverage'.to_sym, 0).to_f
       if overall_coverage < minimum_coverage
-        puts "Overall coverage #{'%.2f' % overall_coverage} is less than minimum #{'%.2f' % minimum_coverage}"
+        puts "Overall coverage #{format('%.2f', overall_coverage)} is less than minimum #{format('%.2f', minimum_coverage)}"
         exit 1
       end
     end

--- a/lib/deep_cover/cli/commands/report.rb
+++ b/lib/deep_cover/cli/commands/report.rb
@@ -6,9 +6,17 @@ module DeepCover
     option '--output', desc: 'output folder', type: :string, default: DeepCover.config.output, aliases: '-o'
     option '--reporter', desc: 'reporter to use', type: :string, default: DeepCover.config.reporter
     option '--open', desc: 'open the output coverage', type: :boolean, default: CLI_DEFAULTS[:open]
+    option '--minimum-coverage', desc: 'minimum coverage percent', type: :numeric, default: 0
     def report
       coverage = Coverage.load
       puts coverage.report(**processed_options)
+
+      overall_coverage = coverage.analysis.overall
+      minimum_coverage = processed_options.fetch('minimum-coverage'.to_sym, 0).to_f
+      if overall_coverage < minimum_coverage
+        puts "Overall coverage #{'%.2f' % overall_coverage} is less than minimum #{'%.2f' % minimum_coverage}"
+        exit 1
+      end
     end
   end
 end


### PR DESCRIPTION
### WHY

Adds a minimum coverage check to the reporting tool, this is useful in CI scenarios where you wish to fail if the coverage has fallen bellow a given threshold.